### PR TITLE
Fixing workflow to correctly override framework version 

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,7 +29,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_KEY}}
 
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore -p:NetCoreTargetFramework=net5.0
 
       - name: Build
         run: dotnet build --configuration Release --no-restore -p:NetCoreTargetFramework=net5.0 -p:PackageVersion=5.0.0


### PR DESCRIPTION
Explicitly sets framework version when invoking `dotnet restore`